### PR TITLE
add a sleep to ram_write

### DIFF
--- a/src/protocol.py
+++ b/src/protocol.py
@@ -352,6 +352,7 @@ class Dell2410:
         # i2c writes sometimes
         while True:
             self._send_gprobe_cmd('\x1a', '\x13', struct.pack(">H", address) + byte)
+            time.sleep(0.01)
             resp = self._recv_gprobe_resp()
             if resp[1] == 0xc: # 0xc is ACK
                 break


### PR DESCRIPTION
This gets the full demo fully working, rather than the simpler scripts I was using. It also slows it down a bit, but it's sadly necessary.